### PR TITLE
change to /bin/sh, use XDG_CONFIG_HOME instead of .config

### DIFF
--- a/nanofetch
+++ b/nanofetch
@@ -1,8 +1,8 @@
-#!/bin/env bash
-if [[ -f "/bedrock/etc/bedrock-release" ]] && [[ $PATH == */bedrock/cross/* ]]; then
+#!/bin/sh
+if [ -f "/bedrock/etc/bedrock-release" ] && [ $PATH == */bedrock/cross/* ]; then
   echo $(tput setab 9) $(tput setab 1) $(tput sgr0) ":| distro | "$(cat /bedrock/etc/bedrock-release)
 else
- if [[ -f "/etc/os-release" ]]; then
+ if [ -f "/etc/os-release" ]; then
   echo $(tput setab 9) $(tput setab 1) $(tput sgr0) ":| distro | "$(cat /etc/os-release | awk -F= '{print $2;exit}'| awk -F\" '{print $1,$2}')
  else
   echo $(tput setab 9) $(tput setab 1) $(tput sgr0) ":| distro | "$(uname -o)
@@ -13,5 +13,5 @@ echo $(tput setab 11) $(tput setab 3) $(tput sgr0) ":| device | "$(uname -n) $(u
 echo $(tput setab 12) $(tput setab 4) $(tput sgr0) ":| host   | "$(cat /sys/devices/virtual/dmi/id/product_name)
 echo $(tput setab 13) $(tput setab 5) $(tput sgr0) ":| shell  | "$(basename $SHELL)
 echo $(tput setab 14) $(tput setab 6) $(tput sgr0) ":| wm     | "$(id=$(xprop -root -notype | awk '$1=="_NET_SUPPORTING_WM_CHECK:"{print $5}'); xprop -id "${id}" -notype -f _NET_WM_NAME 8t | grep "_NET_WM_NAME = " | cut --delimiter=' ' --fields=3 | cut --delimiter='"' --fields=2)
-echo $(tput setab 15) $(tput setab 7) $(tput sgr0) ":| gtk    | "$(grep 'gtk-theme-name' $HOME/.config/gtk-3.0/settings.ini | cut -d' ' -f 3)
+echo $(tput setab 15) $(tput setab 7) $(tput sgr0) ":| gtk    | "$(grep 'gtk-theme-name' $XDG_CONFIG_HOME/gtk-3.0/settings.ini | cut -d' ' -f 3)
 echo $(tput setab 8) $(tput setab 0) $(tput sgr0) ":| pkgs   | "$(ls -1q /usr/bin | wc -l)

--- a/nanofetch-fish
+++ b/nanofetch-fish
@@ -13,5 +13,5 @@ echo (tput setab 11) (tput setab 3) (tput sgr0) ":| device | "(uname -n) $(uname
 echo (tput setab 12) (tput setab 4) (tput sgr0) ":| host   | "(cat /sys/devices/virtual/dmi/id/product_name)
 echo (tput setab 13) (tput setab 5) (tput sgr0) ":| shell  | "(basename $SHELL)
 echo (tput setab 14) (tput setab 6) (tput sgr0) ":| wm     | "(id=(xprop -root -notype | awk '$1=="_NET_SUPPORTING_WM_CHECK:"{print $5}'); xprop -id "{id}" -notype -f _NET_WM_NAME 8t | grep "_NET_WM_NAME = " | cut --delimiter=' ' --fields=3 | cut --delimiter='"' --fields=2)
-echo (tput setab 15) (tput setab 7) (tput sgr0) ":| gtk    | "(grep 'gtk-theme-name' $HOME/.config/gtk-3.0/settings.ini | cut -d' ' -f 3)
+echo (tput setab 15) (tput setab 7) (tput sgr0) ":| gtk    | "(grep 'gtk-theme-name' $XDG_CONFIG_HOME/gtk-3.0/settings.ini | cut -d' ' -f 3)
 echo (tput setab 8) (tput setab 0) (tput sgr0) ":| pkgs   | "(ls -1q /usr/bin | wc -l)


### PR DESCRIPTION
Switch to a more system agnostic shell. Use `$XDG_CONFIG_HOME` since not everyone uses or has a `~/.config` folder.

I would also recommend properly quoting some things so as to avoid any potential conflicts. Though that is more personal preference and thus not included in this commit.