### PR TITLE
make slightly less bad

### DIFF
--- a/nanofetch
+++ b/nanofetch
@@ -1,17 +1,28 @@
 #!/bin/sh
-if [ -f "/bedrock/etc/bedrock-release" ] && [ $PATH == */bedrock/cross/* ]; then
-  echo $(tput setab 9) $(tput setab 1) $(tput sgr0) ":| distro | "$(cat /bedrock/etc/bedrock-release)
+
+prin() {
+	printf "\033[10%sm \033[4%sm \033[0m :| %-6s | %s\n" "$1" "$1" "$2" "$3"
+}
+
+if [ -f /bedrock/etc/bedrock-release ]; then
+	read -r distro < /bedrock/etc/bedrock-release
+	prin 1 distro "$distro"
+elif [ -f /etc/os-release ]; then
+	. /etc/os-release
+	prin 1 distro "$NAME"
 else
- if [ -f "/etc/os-release" ]; then
-  echo $(tput setab 9) $(tput setab 1) $(tput sgr0) ":| distro | "$(cat /etc/os-release | awk -F= '{print $2;exit}'| awk -F\" '{print $1,$2}')
- else
-  echo $(tput setab 9) $(tput setab 1) $(tput sgr0) ":| distro | "$(uname -o)
- fi
+	prin 1 os "$(uname -o)"
 fi
-echo $(tput setab 10) $(tput setab 2) $(tput sgr0) ":| kernel | "$(uname -r)
-echo $(tput setab 11) $(tput setab 3) $(tput sgr0) ":| device | "$(uname -n) $(uname -m)
-echo $(tput setab 12) $(tput setab 4) $(tput sgr0) ":| host   | "$(cat /sys/devices/virtual/dmi/id/product_name)
-echo $(tput setab 13) $(tput setab 5) $(tput sgr0) ":| shell  | "$(basename $SHELL)
-echo $(tput setab 14) $(tput setab 6) $(tput sgr0) ":| wm     | "$(id=$(xprop -root -notype | awk '$1=="_NET_SUPPORTING_WM_CHECK:"{print $5}'); xprop -id "${id}" -notype -f _NET_WM_NAME 8t | grep "_NET_WM_NAME = " | cut --delimiter=' ' --fields=3 | cut --delimiter='"' --fields=2)
-echo $(tput setab 15) $(tput setab 7) $(tput sgr0) ":| gtk    | "$(grep 'gtk-theme-name' $XDG_CONFIG_HOME/gtk-3.0/settings.ini | cut -d' ' -f 3)
-echo $(tput setab 8) $(tput setab 0) $(tput sgr0) ":| pkgs   | "$(ls -1q /usr/bin | wc -l)
+
+prin 2 kernel "$(uname -r)"
+prin 3 device "$(uname -n) $(uname -m)"
+
+read -r dev < /sys/devices/virtual/dmi/id/product_name
+prin 4 host "$dev"
+prin 5 shell "${SHELL##*/}"
+
+id=$(xprop -root -notype | awk '$1=="_NET_SUPPORTING_WM_CHECK:"{print $5}');
+prin 6 wm "$(xprop -id "${id}" -notype -f _NET_WM_NAME 8t | grep "_NET_WM_NAME = " \
+	| cut --delimiter=' ' --fields=3 | cut --delimiter='"' --fields=2)"
+prin 7 gtk "$(grep gtk-theme-name "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d= -f2 )"
+prin 0 bins "$(find /usr/bin | wc -l)"


### PR DESCRIPTION
you were using bashisms in a script that uses /bin/sh

you were were using 2 awks to parse a file that could be parsed natively

you were doing recursive 'if' when you could just use elif

you were forcing XDG_CONFIG_HOME for gtk when by default it's unset

i kept the wm the same because it's a pain to get...

for me there was a space before my OS name

for me the gtk theme kept the key (gtk-theme-name=)

'pkgs' is misleading because it's just the amount of binaries, so i
renamed that

basename is useless

tput is useless and non-standard

you shouldn't pipe ls so I used find instead

it's still messy but at least it's a bit less-bad